### PR TITLE
chore: change some variable declarations to const

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ const indexCache = new require('./lib/cache.js')({
 
 module.exports = (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*')
-  let [path, params] = retrieveUrl(req.url)
+  const [path, params] = retrieveUrl(req.url)
   switch(path) {
-    case '/history': 
+    case '/history':
       return require('./lib/db').getApiResponses(params)
       break
     case '/favicon.ico':

--- a/lib/db.js
+++ b/lib/db.js
@@ -27,7 +27,7 @@ const Api = dynamoose.model('api', {
 })
 
 function saveApiResponse (data) {
-  var response = new Api(Object.assign({
+  const response = new Api(Object.assign({
     id: Math.floor(Math.random() * new Date().getTime()),
     timestamp: new Date().getTime()
   }, data))
@@ -36,7 +36,7 @@ function saveApiResponse (data) {
 
 function getApiResponses ({start}) {
   if (!start) {
-    let today = new Date()
+    const today = new Date()
     start = today - (1000 * 60 * 60 * 24 * 2) * 5
   }
   return Api

--- a/lib/fetchData.js
+++ b/lib/fetchData.js
@@ -97,7 +97,7 @@ function swapLabelToName (data, exchangesLabels) {
 
 function applyTaxes (data, exchangeTaxes) {
   return data.map(el => {
-    let elTaxes = _get(exchangeTaxes, el.id)
+    const elTaxes = _get(exchangeTaxes, el.id)
     if (el.id === 'Bitwage') {
       el.priceAfterTaxes = el.price + (el.price * elTaxes.transferBTC)
     } else {
@@ -155,7 +155,7 @@ function arrayrify (data) {
 }
 
 function getExchanges (data) {
-  let exchanges = _get(data, 'ticker_12h.exchanges') || handleError('nodata')
+  const exchanges = _get(data, 'ticker_12h.exchanges') || handleError('nodata')
   _get(data, 'ticker_1h.exchanges') || handleError('nodata')
     .forEach((el, key) => {
       exchanges[key] = el
@@ -169,7 +169,7 @@ function parseRequest (data) {
 }
 
 function retrieveBTCSummary () {
-  let sourceValues = {}
+  const sourceValues = {}
   return fetch('http://api.bitvalor.com/v1/ticker.json')
     .then(parseRequest)
     .then(getExchanges)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,8 +23,8 @@ function retrieveUrl (url) {
   path = path.replace('/api', '')
   params = params ? params.split('&') : []
   params = params.reduce((result, param) => {
-    let [key, value] = param.split('=')
-    result[key] = value 
+    const [key, value] = param.split('=')
+    result[key] = value
     return result
   }, {})
   return [path, params]


### PR DESCRIPTION
Some variables were not being mutated, so they could
be declared with the keyword `const`.